### PR TITLE
Spectrum model improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pedinf/diagnostics.py
+++ b/pedinf/diagnostics.py
@@ -27,36 +27,20 @@ class SpectrometerModel:
         self.model = profile_model
         self.model.update_radius(self.instfunc.radius.flatten())
 
-        self.n_positions, self.n_spectra, _, _ = self.response.response.shape
+        self.n_positions = self.response.n_positions
+        self.n_spectra = self.response.n_spectra
         self.n_predictions = self.n_positions * self.n_spectra
         self.n_weights = self.instfunc.weights.shape[1]
         self.spectrum_shape = (self.n_positions, self.n_spectra, self.n_weights)
         self.te_slc = slice(0, self.model.n_parameters)
         self.ne_slc = slice(self.model.n_parameters, 2 * self.model.n_parameters)
 
-    def spectrum(self, Te: ndarray, ne: ndarray) -> ndarray:
-        ln_te = log(Te)
-        coeffs = ne * self.instfunc.weights
-        y = self.response.get_response(ln_te, self.instfunc.scattering_angle)
-        y *= coeffs[:, None, :]
-        return y.sum(axis=2)
-
-    def spectrum_jacobian(self, Te: ndarray, ne: ndarray):
-        ln_te = log(Te)
-        coeffs = ne * self.instfunc.weights
-        dS_dT, dS_dn = self.response.get_response_and_gradient(
-            ln_te, self.instfunc.scattering_angle
-        )
-        dS_dT *= (coeffs / Te)[:, None, :]
-        dS_dn *= self.instfunc.weights[:, None, :]
-        return dS_dT, dS_dn
-
     def predictions(self, theta: ndarray) -> ndarray:
         Te = self.model.forward_prediction(theta[self.te_slc])
         ne = self.model.forward_prediction(theta[self.ne_slc])
         Te.resize(self.instfunc.radius.shape)
         ne.resize(self.instfunc.radius.shape)
-        return self.spectrum(Te, ne).flatten()
+        return self.response.spectrum(Te, ne, self.instfunc.weights, self.instfunc.scattering_angle).flatten()
 
     def predictions_jacobian(self, theta: ndarray) -> ndarray:
         Te, model_jac_Te = self.model.forward_prediction_and_jacobian(theta[self.te_slc])
@@ -66,8 +50,7 @@ class SpectrometerModel:
         model_jac_Te.resize([*self.instfunc.radius.shape, self.model.n_parameters])
         model_jac_ne.resize([*self.instfunc.radius.shape, self.model.n_parameters])
 
-        dT, dn = self.spectrum_jacobian(Te, ne)
-
+        dT, dn = self.response.spectrum_jacobian(Te, ne, self.instfunc.weights, self.instfunc.scattering_angle)
         jac_Te = einsum("iqk, ijq -> ijk", model_jac_Te, dT)
         jac_ne = einsum("iqk, ijq -> ijk", model_jac_ne, dn)
 

--- a/pedinf/spectrum.py
+++ b/pedinf/spectrum.py
@@ -1,4 +1,4 @@
-from numpy import array, sqrt, cos, pi, exp, searchsorted
+from numpy import array, sqrt, cos, pi, exp, searchsorted, stack
 from numpy import ndarray, linspace, zeros
 from scipy.interpolate import RectBivariateSpline
 from pedinf.spline import cubic_spline_coefficients
@@ -201,44 +201,49 @@ class SpectralResponse1D:
         # build the splines for all spatial / spectral channels
         self.n_positions, self.n_spectra, self.n_knots = self.response.shape
 
-        self.a_rspn = zeros([self.n_positions, self.n_spectra, self.n_knots - 1])
-        self.b_rspn = zeros([self.n_positions, self.n_spectra, self.n_knots - 1])
-        self.a_grad = zeros([self.n_positions, self.n_spectra, self.n_knots - 1])
-        self.b_grad = zeros([self.n_positions, self.n_spectra, self.n_knots - 1])
+        self.y = stack([response, scattering_angle_gradient], axis=3)
+        self.a = zeros([self.n_positions, self.n_spectra, self.n_knots - 1, 2])
+        self.b = zeros([self.n_positions, self.n_spectra, self.n_knots - 1, 2])
         for i in range(self.n_positions):
             for j in range(self.n_spectra):
                 a, b = cubic_spline_coefficients(
                     self.ln_te_knots, self.response[i, j, :]
                 )
-                self.a_rspn[i, j, :] = a
-                self.b_rspn[i, j, :] = b
+                self.a[i, j, :, 0] = a
+                self.b[i, j, :, 0] = b
 
                 a, b = cubic_spline_coefficients(
                     self.ln_te_knots, self.angle_grad[i, j, :]
                 )
-                self.a_grad[i, j, :] = a
-                self.b_grad[i, j, :] = b
+                self.a[i, j, :, 1] = a
+                self.b[i, j, :, 1] = b
 
     def get_response(self, ln_te: ndarray, scattering_angle: ndarray):
-        y = zeros((self.n_positions, self.n_spectra, ln_te.shape[1]))
-
         # get the spline coordinate
         inds = searchsorted(self.ln_te_knots, ln_te) - 1
         t = (ln_te - self.ln_te_knots[inds]) / self.knot_spacing
         u = 1 - t
         ut = u * t
-        res_spline = (
-            self.response[:, :, inds] * u + self.response[:, :, inds + 1] * t
-            + ut * (u * self.a_rspn[:, :, inds] + t * self.b_rspn[:, :, inds])
-        )
-        grad_spline = (
-            self.angle_grad[:, :, inds] * u + self.angle_grad[:, :, inds + 1] * t
-            + ut * (u * self.a_grad[:, :, inds] + t * self.b_grad[:, :, inds])
-        )
-        angle_diff = scattering_angle - self.scattering_angle[:, None]
 
-        y = res_spline + angle_diff * grad_spline
-        return y
+        y_u = zeros((self.n_positions, self.n_spectra, ln_te.shape[1], 2))
+        y_t = zeros((self.n_positions, self.n_spectra, ln_te.shape[1], 2))
+        a_slc = zeros((self.n_positions, self.n_spectra, ln_te.shape[1], 2))
+        b_slc = zeros((self.n_positions, self.n_spectra, ln_te.shape[1], 2))
+
+        for i in range(self.n_positions):
+            y_u[i, :, :, :] = self.y[i, :, :, :][:, inds[i, :], :]
+            y_t[i, :, :, :] = self.y[i, :, :, :][:, inds[i, :] + 1, :]
+            a_slc[i, :, :, :] = self.a[i, :, :, :][:, inds[i, :], :]
+            b_slc[i, :, :, :] = self.b[i, :, :, :][:, inds[i, :], :]
+
+        t1 = u[:, None, :, None] * y_u
+        t2 = t[:, None, :, None] * y_t
+        t3 = u[:, None, :, None] * a_slc
+        t4 = t[:, None, :, None] * b_slc
+        splines = (t1 + t2 + (t3 + t4) * ut[:, None, :, None])
+
+        angle_diff = scattering_angle - self.scattering_angle[:, None]
+        return splines[:, :, :, 0] + angle_diff[:, None, :] * splines[:, :, :, 1]
 
     @classmethod
     def calculate_response(
@@ -272,4 +277,4 @@ class SpectralResponse1D:
                 response[i, j, :] = f0
                 angle_grad[i, j, :] = 0.5 * (f2 - f1) / dA
 
-        return cls(ln_te, scattering_angles, response, angle_grad)
+        return cls(ln_te, scattering_angles[spatial_channels], response, angle_grad)

--- a/pedinf/spectrum/__init__.py
+++ b/pedinf/spectrum/__init__.py
@@ -308,6 +308,27 @@ class SpectralResponse:
         n_temps=128,
         use_jax=True,
     ):
+        response_data = SpectralResponse.calculate_response_data(
+            wavelengths=wavelengths,
+            transmissions=transmissions,
+            scattering_angles=scattering_angles,
+            spatial_channels=spatial_channels,
+            ln_te_range=ln_te_range,
+            n_temps=n_temps,
+            use_jax=use_jax,
+        )
+        return cls(**response_data)
+
+    @staticmethod
+    def calculate_response_data(
+        wavelengths: ndarray,
+        transmissions: ndarray,
+        scattering_angles: ndarray,
+        spatial_channels: ndarray,
+        ln_te_range=(-3, 10),
+        n_temps=128,
+        use_jax=True,
+    ) -> dict:
         n_spectral_chans = 4
         ln_te = linspace(*ln_te_range, n_temps)
         te_axis = exp(ln_te)
@@ -351,7 +372,7 @@ class SpectralResponse:
                 temp_grad[i, j, :] = 0.5 * (dte_2 - dte_1) / dT
                 double_grad[i, j, :] = 0.5 * (dphi_2 - dphi_1) / dT
 
-        return cls(
+        return dict(
             ln_te=ln_te,
             scattering_angle=scattering_angles[spatial_channels],
             response=response,

--- a/pedinf/spectrum/__init__.py
+++ b/pedinf/spectrum/__init__.py
@@ -206,7 +206,7 @@ class SpectralResponse:
         scattering_angle_gradient: ndarray,
         ln_te_gradient: ndarray,
         ln_te_and_angle_gradient: ndarray,
-        use_jax=True,
+        jit_compile=False,
     ):
         self.ln_te_knots = ln_te.astype(float32)
         self.knot_spacing = ln_te[1] - ln_te[0]
@@ -244,7 +244,7 @@ class SpectralResponse:
         self.b_no_grads = self.b[:, :, :, :2].copy()
         self.y_no_grads = self.y[:, :, :, :2].copy()
 
-        if use_jax:
+        if jit_compile:
             import pedinf.spectrum.jax as spec
         else:
             import pedinf.spectrum.numpy as spec
@@ -306,7 +306,7 @@ class SpectralResponse:
         spatial_channels: ndarray,
         ln_te_range=(-3, 10),
         n_temps=128,
-        use_jax=True,
+        jit_compile=False,
     ):
         response_data = SpectralResponse.calculate_response_data(
             wavelengths=wavelengths,
@@ -315,9 +315,8 @@ class SpectralResponse:
             spatial_channels=spatial_channels,
             ln_te_range=ln_te_range,
             n_temps=n_temps,
-            use_jax=use_jax,
         )
-        return cls(**response_data)
+        return cls(**response_data, jit_compile=jit_compile)
 
     @staticmethod
     def calculate_response_data(
@@ -327,7 +326,6 @@ class SpectralResponse:
         spatial_channels: ndarray,
         ln_te_range=(-3, 10),
         n_temps=128,
-        use_jax=True,
     ) -> dict:
         n_spectral_chans = 4
         ln_te = linspace(*ln_te_range, n_temps)
@@ -378,6 +376,5 @@ class SpectralResponse:
             response=response,
             scattering_angle_gradient=angle_grad,
             ln_te_gradient=temp_grad,
-            ln_te_and_angle_gradient=double_grad,
-            use_jax=use_jax,
+            ln_te_and_angle_gradient=double_grad
         )

--- a/pedinf/spectrum/__init__.py
+++ b/pedinf/spectrum/__init__.py
@@ -103,7 +103,7 @@ def calculate_filter_response(
     return (spectrum * integration_weights[:, None, None]).sum(axis=0)
 
 
-class SpectralResponse:
+class SpectralResponse2D:
     def __init__(
         self, ln_te_axes: ndarray, scattering_angle_axes: ndarray, response: ndarray
     ):
@@ -197,7 +197,7 @@ class SpectralResponse:
         return cls(ln_te_axes, scattering_angle_axes, response)
 
 
-class SpectralResponse1D:
+class SpectralResponse:
     def __init__(
         self,
         ln_te: ndarray,
@@ -251,6 +251,8 @@ class SpectralResponse1D:
 
         self.__spectrum = spec.spectrum
         self.__spectrum_jacobian = spec.spectrum_jacobian
+        self.__response = spec.response
+        self.__response_and_grad = spec.response_and_grad
 
     def spectrum(
         self, Te: ndarray, ne: ndarray, weights: ndarray, scattering_angle: ndarray
@@ -275,6 +277,19 @@ class SpectralResponse1D:
             ne,
             scattering_angle - self.scattering_angle[:, None],
             weights,
+            self.y,
+            self.a,
+            self.b,
+            self.ln_te_knots,
+            self.knot_spacing,
+        )
+
+    def response_and_grad(
+        self, ln_te: ndarray, scattering_angle: ndarray
+    ):
+        return self.__response_and_grad(
+            ln_te,
+            scattering_angle - self.scattering_angle[:, None],
             self.y,
             self.a,
             self.b,

--- a/pedinf/spectrum/__init__.py
+++ b/pedinf/spectrum/__init__.py
@@ -227,8 +227,9 @@ class SpectralResponse1D:
             axis=3,
             dtype=float32,
         )
-        self.a = zeros(self.y.shape, dtype=float32)
-        self.b = zeros(self.y.shape, dtype=float32)
+        coeff_shape = (self.n_positions, self.n_spectra, self.n_knots - 1, 4)
+        self.a = zeros(coeff_shape, dtype=float32)
+        self.b = zeros(coeff_shape, dtype=float32)
 
         for i in range(self.n_positions):
             for j in range(self.n_spectra):

--- a/pedinf/spectrum/jax.py
+++ b/pedinf/spectrum/jax.py
@@ -1,0 +1,102 @@
+from numpy import ndarray
+import jax.numpy as jnp
+from jax import jit
+
+
+def response(
+    ln_te: ndarray,
+    angle_diffs: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    # get the spline coordinate
+    inds = jnp.searchsorted(ln_te_knots, ln_te) - 1
+    t = (ln_te - ln_te_knots[inds]) / knot_spacing
+    u = 1 - t
+    ut = u * t
+
+    y_u = jnp.take_along_axis(y, inds[:, None, :, None], axis=2)
+    y_t = jnp.take_along_axis(y, inds[:, None, :, None] + 1, axis=2)
+    a_slc = jnp.take_along_axis(a, inds[:, None, :, None], axis=2)
+    b_slc = jnp.take_along_axis(b, inds[:, None, :, None], axis=2)
+
+    t1 = u[:, None, :, None] * y_u
+    t2 = t[:, None, :, None] * y_t
+    t3 = u[:, None, :, None] * a_slc
+    t4 = t[:, None, :, None] * b_slc
+    splines = t1 + t2 + (t3 + t4) * ut[:, None, :, None]
+    return splines[:, :, :, 0] + angle_diffs[:, None, :] * splines[:, :, :, 1]
+
+
+def response_and_grad(
+    ln_te: ndarray,
+    angle_diffs: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    # get the spline coordinate
+    inds = jnp.searchsorted(ln_te_knots, ln_te) - 1
+    t = (ln_te - ln_te_knots[inds]) / knot_spacing
+    u = 1 - t
+    ut = u * t
+
+    y_u = jnp.take_along_axis(y, inds[:, None, :, None], axis=2)
+    y_t = jnp.take_along_axis(y, inds[:, None, :, None] + 1, axis=2)
+    a_slc = jnp.take_along_axis(a, inds[:, None, :, None], axis=2)
+    b_slc = jnp.take_along_axis(b, inds[:, None, :, None], axis=2)
+
+    t1 = u[:, None, :, None] * y_u
+    t2 = t[:, None, :, None] * y_t
+    t3 = u[:, None, :, None] * a_slc
+    t4 = t[:, None, :, None] * b_slc
+    splines = t1 + t2 + (t3 + t4) * ut[:, None, :, None]
+    return (
+        splines[:, :, :, 2] + angle_diffs[:, None, :] * splines[:, :, :, 3],
+        splines[:, :, :, 0] + angle_diffs[:, None, :] * splines[:, :, :, 1],
+    )
+
+
+@jit
+def spectrum(
+    Te: ndarray,
+    ne: ndarray,
+    angle_diffs: ndarray,
+    weights: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    ln_te = jnp.log(Te)
+    coeffs = ne * weights
+    res = response(
+        ln_te, angle_diffs, y, a, b, ln_te_knots, knot_spacing,
+    )
+    return jnp.sum(res * coeffs[:, None, :], axis=2)
+
+
+@jit
+def spectrum_jacobian(
+    Te: ndarray,
+    ne: ndarray,
+    angle_diffs: ndarray,
+    weights: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    ln_te = jnp.log(Te)
+    gradient, res = response_and_grad(
+        ln_te, angle_diffs, y, a, b, ln_te_knots, knot_spacing,
+    )
+    coeffs = (ne * weights) / Te
+    return gradient * coeffs[:, None, :], res * weights[:, None, :]

--- a/pedinf/spectrum/jax.py
+++ b/pedinf/spectrum/jax.py
@@ -1,6 +1,22 @@
 from numpy import ndarray
+try:
+    from jax import jit
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        """\n
+        \r[ SpectralResponse error ]
+        \r| Failed to import the 'jax' python package while initialising
+        \r| an instance of the SpectralResponse class.
+        \r|
+        \r| If the 'jit_compile' argument is set to True, the 'jax'
+        \r| python package is used to jit-compile functions used to
+        \r| predict measured spectral response values.
+        \r|
+        \r| jax can be installed as an optional dependency using:
+        \r| >> pip install pedestal-inference[jit]
+        """
+    )
 import jax.numpy as jnp
-from jax import jit
 
 
 def response(

--- a/pedinf/spectrum/jax.py
+++ b/pedinf/spectrum/jax.py
@@ -13,7 +13,10 @@ def response(
     knot_spacing: float,
 ):
     # get the spline coordinate
-    inds = jnp.searchsorted(ln_te_knots, ln_te) - 1
+    inds = jnp.searchsorted(
+        ln_te_knots,
+        jnp.clip(ln_te, ln_te_knots[0], ln_te_knots[-1])
+    ) - 1
     t = (ln_te - ln_te_knots[inds]) / knot_spacing
     u = 1 - t
     ut = u * t
@@ -41,7 +44,10 @@ def response_and_grad(
     knot_spacing: float,
 ):
     # get the spline coordinate
-    inds = jnp.searchsorted(ln_te_knots, ln_te) - 1
+    inds = jnp.searchsorted(
+        ln_te_knots,
+        jnp.clip(ln_te, ln_te_knots[0], ln_te_knots[-1])
+    ) - 1
     t = (ln_te - ln_te_knots[inds]) / knot_spacing
     u = 1 - t
     ut = u * t

--- a/pedinf/spectrum/numpy.py
+++ b/pedinf/spectrum/numpy.py
@@ -1,4 +1,4 @@
-from numpy import ndarray, log, searchsorted, take_along_axis
+from numpy import ndarray, log, searchsorted, take_along_axis, clip
 
 
 def response(
@@ -11,7 +11,7 @@ def response(
     knot_spacing: float,
 ):
     # get the spline coordinate
-    inds = searchsorted(ln_te_knots, ln_te) - 1
+    inds = searchsorted(ln_te_knots, clip(ln_te, ln_te_knots[0], ln_te_knots[-1])) - 1
     t = (ln_te - ln_te_knots[inds]) / knot_spacing
     u = 1 - t
     ut = u * t
@@ -39,7 +39,7 @@ def response_and_grad(
     knot_spacing: float,
 ):
     # get the spline coordinate
-    inds = searchsorted(ln_te_knots, ln_te) - 1
+    inds = searchsorted(ln_te_knots, clip(ln_te, ln_te_knots[0], ln_te_knots[-1])) - 1
     t = (ln_te - ln_te_knots[inds]) / knot_spacing
     u = 1 - t
     ut = u * t

--- a/pedinf/spectrum/numpy.py
+++ b/pedinf/spectrum/numpy.py
@@ -1,0 +1,98 @@
+from numpy import ndarray, log, searchsorted, take_along_axis
+
+
+def response(
+    ln_te: ndarray,
+    angle_diffs: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    # get the spline coordinate
+    inds = searchsorted(ln_te_knots, ln_te) - 1
+    t = (ln_te - ln_te_knots[inds]) / knot_spacing
+    u = 1 - t
+    ut = u * t
+
+    y_u = take_along_axis(y, inds[:, None, :, None], axis=2)
+    y_t = take_along_axis(y, inds[:, None, :, None] + 1, axis=2)
+    a_slc = take_along_axis(a, inds[:, None, :, None], axis=2)
+    b_slc = take_along_axis(b, inds[:, None, :, None], axis=2)
+
+    t1 = u[:, None, :, None] * y_u
+    t2 = t[:, None, :, None] * y_t
+    t3 = u[:, None, :, None] * a_slc
+    t4 = t[:, None, :, None] * b_slc
+    splines = t1 + t2 + (t3 + t4) * ut[:, None, :, None]
+    return splines[:, :, :, 0] + angle_diffs[:, None, :] * splines[:, :, :, 1]
+
+
+def response_and_grad(
+    ln_te: ndarray,
+    angle_diffs: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    # get the spline coordinate
+    inds = searchsorted(ln_te_knots, ln_te) - 1
+    t = (ln_te - ln_te_knots[inds]) / knot_spacing
+    u = 1 - t
+    ut = u * t
+
+    y_u = take_along_axis(y, inds[:, None, :, None], axis=2)
+    y_t = take_along_axis(y, inds[:, None, :, None] + 1, axis=2)
+    a_slc = take_along_axis(a, inds[:, None, :, None], axis=2)
+    b_slc = take_along_axis(b, inds[:, None, :, None], axis=2)
+
+    t1 = u[:, None, :, None] * y_u
+    t2 = t[:, None, :, None] * y_t
+    t3 = u[:, None, :, None] * a_slc
+    t4 = t[:, None, :, None] * b_slc
+    splines = t1 + t2 + (t3 + t4) * ut[:, None, :, None]
+    return (
+        splines[:, :, :, 2] + angle_diffs[:, None, :] * splines[:, :, :, 3],
+        splines[:, :, :, 0] + angle_diffs[:, None, :] * splines[:, :, :, 1],
+    )
+
+
+def spectrum(
+    Te: ndarray,
+    ne: ndarray,
+    angle_diffs: ndarray,
+    weights: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    ln_te = log(Te)
+    coeffs = ne * weights
+    res = response(
+        ln_te, angle_diffs, y, a, b, ln_te_knots, knot_spacing,
+    )
+    return (res * coeffs[:, None, :]).sum(axis=2)
+
+
+def spectrum_jacobian(
+    Te: ndarray,
+    ne: ndarray,
+    angle_diffs: ndarray,
+    weights: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    ln_te = log(Te)
+    gradient, res = response_and_grad(
+        ln_te, angle_diffs, y, a, b, ln_te_knots, knot_spacing,
+    )
+    coeffs = (ne * weights) / Te
+    return gradient * coeffs[:, None, :], res * weights[:, None, :]

--- a/pedinf/spline.py
+++ b/pedinf/spline.py
@@ -1,0 +1,48 @@
+from numpy import ndarray, zeros, searchsorted
+from scipy.linalg import solveh_banded
+
+
+def cubic_spline_coefficients(x: ndarray, y: ndarray):
+    assert x.size == y.size
+    assert x.ndim == y.ndim == 1
+    assert x.size > 2
+    A = zeros([2, x.size])
+    b = zeros([x.size])
+    n = x.size - 1
+
+    dx = x[1:] - x[:-1]
+    dy = y[1:] - y[:-1]
+
+    assert (dx > 0).all()
+
+    v = 1 / dx
+    v_sqr = v**2
+    g = v_sqr * dy
+
+    # build matrix diagonal
+    A[1, 0] = 2 * v[0]
+    A[1, 1:-1] = 2 * (v[1:] + v[:-1])
+    A[1, n] = 2 * v[-1]
+
+    # build off-diagonals
+    A[0, 1:] = v
+
+    # build linear system target values
+    b[1:-1] = 3 * (g[:-1] + g[1:])
+    b[0] = 3 * g[0]
+    b[n] = 3 * g[-1]
+
+    # solve the system to get the cubic coefficients
+    k = solveh_banded(A, b)
+    a_coeffs = k[:-1]*dx - dy
+    b_coeffs = -k[1:]*dx + dy
+    return a_coeffs, b_coeffs
+
+
+def evaluate_cubic_spline(x: ndarray, x_knots: ndarray, y_knots: ndarray, a: ndarray, b: ndarray):
+    inds = searchsorted(x_knots, x) - 1
+    dk = x_knots[1:] - x_knots[:-1]
+    t = (x - x_knots[inds]) / dk[inds]
+    u = 1 - t
+    return y_knots[inds] * u + y_knots[inds + 1] * t + u * t * (u * a[inds] + t * b[inds])
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["pedinf", "pedinf.models", "pedinf.analysis"]
+packages = ["pedinf", "pedinf.models", "pedinf.analysis", "pedinf.spectrum"]
 
 [project]
 name = "pedestal-inference"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
   { name="Chris Bowman", email="chris.bowman.physics@gmail.com" },
 ]
@@ -20,11 +20,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
-    "numpy >= 1.20",
-    "scipy >= 1.6.3",
-    "inference-tools >= 0.12.0",
+    "numpy >= 1.22.4",
+    "scipy >= 1.10.1",
+    "inference-tools >= 0.13.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ tests = [
     "pytest >= 3.3.0",
     "pytest-cov >= 3.0.0"
 ]
+jit = [
+    "jax >= 0.4.30"
+]

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -1,0 +1,92 @@
+from numpy import exp, linspace, zeros, arange, ndarray
+from pedinf.spectrum import SpectralResponse1D, calculate_filter_response
+
+
+def calculate_response(
+    wavelengths: ndarray,
+    transmissions: ndarray,
+    scattering_angles: ndarray,
+    spatial_channels: ndarray,
+    ln_te_range=(-3, 10),
+    delta_angle_range=(-0.03, 0.03),
+    n_temps=64,
+    n_angles=16,
+):
+    n_spectral_chans = 4
+    ln_te = linspace(*ln_te_range, n_temps)
+    te_axis = exp(ln_te)
+    delta_angle = linspace(*delta_angle_range, n_angles)
+
+    response = zeros([spatial_channels.size, n_spectral_chans, n_temps, n_angles])
+    gradient = zeros([spatial_channels.size, n_spectral_chans, n_temps, n_angles])
+    ln_te_axes = zeros([spatial_channels.size, n_temps])
+    scattering_angle_axes = zeros([spatial_channels.size, n_angles])
+    dte = 1e-4
+
+    for i, chan in enumerate(spatial_channels):
+        ln_te_axes[i, :] = ln_te
+        scattering_angle_axes[i, :] = delta_angle + scattering_angles[chan]
+        for j in range(n_spectral_chans):
+            response[i, j, :, :] = calculate_filter_response(
+                electron_temperature=te_axis,
+                scattering_angle=scattering_angle_axes[i, :],
+                wavelength=wavelengths[chan, j, :],
+                transmission=transmissions[chan, j, :],
+            )
+
+            f1 = calculate_filter_response(
+                electron_temperature=exp(ln_te - dte),
+                scattering_angle=scattering_angle_axes[i, :],
+                wavelength=wavelengths[chan, j, :],
+                transmission=transmissions[chan, j, :],
+            )
+
+            f2 = calculate_filter_response(
+                electron_temperature=exp(ln_te + dte),
+                scattering_angle=scattering_angle_axes[i, :],
+                wavelength=wavelengths[chan, j, :],
+                transmission=transmissions[chan, j, :],
+            )
+
+            gradient[i, j, :, :] = 0.5 * (f2 - f1) / dte
+    return ln_te_axes, scattering_angle_axes, response, gradient
+
+
+def superguass(x, c, w, n=4):
+    z = (x - c) / w
+    return exp(-0.5 * z**n)
+
+
+def generate_testing_filters():
+    # parameters for a set of testing polychromator filters
+    # generated using super-gaussians
+    wavelength_starts = [1.053e-06, 1.035e-06, 9.8e-07, 8.1e-07]
+    wavelength_ends = [1.064e-06, 1.06e-06, 1.0462e-06, 1.0075e-06]
+    amplitudes = [1.0, 1.14, 1.43, 1.6]
+    widths = [2.55e-9, 7e-9, 2.1e-8, 7.1e-8]
+    centres = [1.058e-6, 1.0477e-6, 1.018e-6, 9.19e-7]
+    exponents = [4, 8, 10, 12]
+
+    # build the transmission data
+    wavelengths = zeros([130, 4, 128])
+    transmissions = zeros([130, 4, 128])
+    for i in range(4):
+        wavelengths[:, i, :] = linspace(wavelength_starts[i], wavelength_ends[i], 128)[None, :]
+        transmissions[:, i, :] = amplitudes[i] * superguass(
+            wavelengths[:, i, :], c=centres[i], w=widths[i], n=exponents[i]
+        )[None, :]
+
+    spatial_channels = arange(0, 130)
+    # generate testing scattering angles from a quadratric
+    coeffs = [7.85941e-07, -6.43046e-03, 2.1297]
+    scattering_angles = coeffs[2] + spatial_channels * coeffs[1] + spatial_channels ** 2 * coeffs[0]
+    return wavelengths, transmissions, scattering_angles, spatial_channels
+
+
+wavelengths, transmissions, scattering_angles, spatial_channels = generate_testing_filters()
+response = SpectralResponse1D.calculate_response(
+    wavelengths=wavelengths,
+    transmissions=transmissions,
+    spatial_channels=spatial_channels,
+    scattering_angles=scattering_angles
+)

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -103,7 +103,7 @@ def test_spectrum_model():
         scattering_angles=scattering_angles,
         ln_te_range=knot_range,
         n_temps=n_knots,
-        use_jax=False
+        jit_compile=False
     )
 
     # generate the target values for spectral response and its gradient

--- a/tests/test_spline.py
+++ b/tests/test_spline.py
@@ -1,0 +1,19 @@
+from numpy import exp, log, sin, linspace
+from pedinf.spline import cubic_spline_coefficients, evaluate_cubic_spline
+
+
+def sinexp(x):
+    return sin(3*x) * exp(-x)
+
+
+def test_cubic_spline():
+    x_knots = exp(linspace(log(1), log(6), 64))
+    x_test = 0.5 * (x_knots[1:] + x_knots[:-1])
+    y_knots = sinexp(x_knots)
+    y_test = sinexp(x_test)
+
+    a_coeff, b_coeff = cubic_spline_coefficients(x_knots, y_knots)
+    y_spline = evaluate_cubic_spline(x_test, x_knots, y_knots, a_coeff, b_coeff)
+
+    max_error = abs(y_spline - y_test).max()
+    assert max_error < 1e-4


### PR DESCRIPTION
 - Increased minimum required Python version from `3.7` to `3.9`.
 - The method for calculating predictions of spectrum measurements has been re-designed in order to improve numerical efficiency and enable jit-compilation via [jax](https://github.com/google/jax). As a result the computation time of the posterior log-probability has been reduced by roughly a factor of 5.
 - jit-compilation via `jax` can be enabled by setting `jit_compile=True` when creating an instance of `SpectralResponse`.
 - `jax` has been added as an optional dependency, which can be included during installation using `pip install pedestal-inference[jit]`.