### PR TITLE
numba jit

### DIFF
--- a/pedinf/diagnostics.py
+++ b/pedinf/diagnostics.py
@@ -26,6 +26,9 @@ class SpectrometerModel:
         instrument_function: InstrumentFunction,
         profile_model: ProfileModel,
     ):
+        # verify that the same number of channels is consistent
+        assert spectral_response.n_positions == instrument_function.radius.shape[0]
+
         self.response = spectral_response
         self.instfunc = instrument_function
         self.model = profile_model

--- a/pedinf/spectrum/__init__.py
+++ b/pedinf/spectrum/__init__.py
@@ -244,10 +244,14 @@ class SpectralResponse:
         self.b_no_grads = self.b[:, :, :, :2].copy()
         self.y_no_grads = self.y[:, :, :, :2].copy()
 
-        if jit_compile:
+
+        if jit_compile == "numba":
+            import pedinf.spectrum.numba as spec
+        elif jit_compile == "jax":
             import pedinf.spectrum.jax as spec
         else:
             import pedinf.spectrum.numpy as spec
+
 
         self.__spectrum = spec.spectrum
         self.__spectrum_jacobian = spec.spectrum_jacobian

--- a/pedinf/spectrum/numba.py
+++ b/pedinf/spectrum/numba.py
@@ -1,0 +1,104 @@
+from numpy import ndarray, log, searchsorted, take_along_axis, clip
+from numba import njit
+
+@njit
+def response(
+    ln_te: ndarray,
+    angle_diffs: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    # get the spline coordinate
+    te_shape = ln_te.shape
+    inds = searchsorted(ln_te_knots, clip(ln_te, ln_te_knots[0], ln_te_knots[-1])) - 1
+    t = (ln_te - ln_te_knots[inds.flatten()].reshape(te_shape)) / knot_spacing
+    u = 1 - t
+    ut = u * t
+
+    y_u = take_along_axis(y, inds[:, None, :, None], axis=2)
+    y_t = take_along_axis(y, inds[:, None, :, None] + 1, axis=2)
+    a_slc = take_along_axis(a, inds[:, None, :, None], axis=2)
+    b_slc = take_along_axis(b, inds[:, None, :, None], axis=2)
+
+    t1 = u[:, None, :, None] * y_u
+    t2 = t[:, None, :, None] * y_t
+    t3 = u[:, None, :, None] * a_slc
+    t4 = t[:, None, :, None] * b_slc
+    splines = t1 + t2 + (t3 + t4) * ut[:, None, :, None]
+    return splines[:, :, :, 0] + angle_diffs[:, None, :] * splines[:, :, :, 1]
+
+
+@njit
+def response_and_grad(
+    ln_te: ndarray,
+    angle_diffs: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    # get the spline coordinate
+    te_shape = ln_te.shape
+    inds = searchsorted(ln_te_knots, clip(ln_te, ln_te_knots[0], ln_te_knots[-1])) - 1
+    t = (ln_te - ln_te_knots[inds.flatten()].reshape(te_shape)) / knot_spacing
+    u = 1 - t
+    ut = u * t
+
+    y_u = take_along_axis(y, inds[:, None, :, None], axis=2)
+    y_t = take_along_axis(y, inds[:, None, :, None] + 1, axis=2)
+    a_slc = take_along_axis(a, inds[:, None, :, None], axis=2)
+    b_slc = take_along_axis(b, inds[:, None, :, None], axis=2)
+
+    t1 = u[:, None, :, None] * y_u
+    t2 = t[:, None, :, None] * y_t
+    t3 = u[:, None, :, None] * a_slc
+    t4 = t[:, None, :, None] * b_slc
+    splines = t1 + t2 + (t3 + t4) * ut[:, None, :, None]
+    return (
+        splines[:, :, :, 2] + angle_diffs[:, None, :] * splines[:, :, :, 3],
+        splines[:, :, :, 0] + angle_diffs[:, None, :] * splines[:, :, :, 1],
+    )
+
+
+@njit
+def spectrum(
+    Te: ndarray,
+    ne: ndarray,
+    angle_diffs: ndarray,
+    weights: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    ln_te = log(Te)
+    coeffs = ne * weights
+    res = response(
+        ln_te, angle_diffs, y, a, b, ln_te_knots, knot_spacing,
+    )
+    return (res * coeffs[:, None, :]).sum(axis=2)
+
+
+@njit
+def spectrum_jacobian(
+    Te: ndarray,
+    ne: ndarray,
+    angle_diffs: ndarray,
+    weights: ndarray,
+    y: ndarray,
+    a: ndarray,
+    b: ndarray,
+    ln_te_knots: ndarray,
+    knot_spacing: float,
+):
+    ln_te = log(Te)
+    gradient, res = response_and_grad(
+        ln_te, angle_diffs, y, a, b, ln_te_knots, knot_spacing,
+    )
+    coeffs = (ne * weights) / Te
+    return gradient * coeffs[:, None, :], res * weights[:, None, :]

--- a/tests/benchmarking.py
+++ b/tests/benchmarking.py
@@ -1,0 +1,45 @@
+from numpy import arange, zeros
+from pedinf.diagnostics import SpectrometerModel
+from pedinf.models import mtanh
+from pedinf.spectrum import SpectralResponse
+from tests.data import build_testing_filters, build_testing_instrument
+from tests.data import test_channel_scattering_angles
+
+
+def profile_func(forward_model, test_params):
+    for i in range(1000):
+        forward_model.predictions_jacobian(test_params)
+
+
+fit_spatial_channels = arange(107, 130)
+inst_data = build_testing_instrument(n_points=20, spatial_channels=fit_spatial_channels)
+wavelengths, transmissions = build_testing_filters()
+
+
+response = SpectralResponse.calculate_response(
+    wavelengths=wavelengths,
+    transmissions=transmissions,
+    scattering_angles=test_channel_scattering_angles,
+    spatial_channels=fit_spatial_channels,
+    ln_te_range = (-1.5, 8.5),
+    n_temps = 128,
+    jit_compile = False,
+)
+
+
+forward_model = SpectrometerModel(
+    spectral_response=response,
+    instrument_function=inst_data,
+    profile_model=mtanh()
+)
+
+
+n_params = 2 * forward_model.model.n_parameters
+test_params = zeros(n_params)
+test_params[forward_model.te_slc] = [1.38, 120., 0.02, 1000., 5.]
+test_params[forward_model.ne_slc] = [1.375, 1e19, 0.015, 5e18, 3e17]
+
+
+
+import cProfile
+cProfile.run("profile_func(forward_model, test_params)")

--- a/tests/benchmarking.py
+++ b/tests/benchmarking.py
@@ -12,7 +12,7 @@ def profile_func(forward_model, test_params):
 
 
 fit_spatial_channels = arange(107, 130)
-inst_data = build_testing_instrument(n_points=20, spatial_channels=fit_spatial_channels)
+inst_data = build_testing_instrument(n_points=9, spatial_channels=fit_spatial_channels)
 wavelengths, transmissions = build_testing_filters()
 
 
@@ -22,10 +22,9 @@ response = SpectralResponse.calculate_response(
     scattering_angles=test_channel_scattering_angles,
     spatial_channels=fit_spatial_channels,
     ln_te_range = (-1.5, 8.5),
-    n_temps = 128,
-    jit_compile = True,
+    n_temps = 64,
+    jit_compile = "numba",
 )
-
 
 forward_model = SpectrometerModel(
     spectral_response=response,
@@ -34,11 +33,11 @@ forward_model = SpectrometerModel(
 )
 
 
+# build a parameter set for testing
 n_params = 2 * forward_model.model.n_parameters
 test_params = zeros(n_params)
 test_params[forward_model.te_slc] = [1.38, 120., 0.02, 1000., 5.]
 test_params[forward_model.ne_slc] = [1.375, 1e19, 0.015, 5e18, 3e17]
-
 
 # run the function once through to complete jit-compilation
 forward_model.predictions(test_params)

--- a/tests/benchmarking.py
+++ b/tests/benchmarking.py
@@ -23,7 +23,7 @@ response = SpectralResponse.calculate_response(
     spatial_channels=fit_spatial_channels,
     ln_te_range = (-1.5, 8.5),
     n_temps = 128,
-    jit_compile = False,
+    jit_compile = True,
 )
 
 
@@ -39,7 +39,8 @@ test_params = zeros(n_params)
 test_params[forward_model.te_slc] = [1.38, 120., 0.02, 1000., 5.]
 test_params[forward_model.ne_slc] = [1.375, 1e19, 0.015, 5e18, 3e17]
 
-
+# run the function once through to complete jit-compilation
+profile_func(forward_model, test_params)
 
 import cProfile
 cProfile.run("profile_func(forward_model, test_params)")

--- a/tests/benchmarking.py
+++ b/tests/benchmarking.py
@@ -39,7 +39,10 @@ test_params = zeros(n_params)
 test_params[forward_model.te_slc] = [1.38, 120., 0.02, 1000., 5.]
 test_params[forward_model.ne_slc] = [1.375, 1e19, 0.015, 5e18, 3e17]
 
+
 # run the function once through to complete jit-compilation
+forward_model.predictions(test_params)
+forward_model.predictions_jacobian(test_params)
 profile_func(forward_model, test_params)
 
 import cProfile

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,0 +1,62 @@
+from numpy import exp, linspace, zeros, tile
+from pedinf.diagnostics import InstrumentFunction
+
+def scattering_angle(R):
+    return 2.27 - 0.65 * R
+
+
+test_channel_radius = linspace(0.21, 1.50, 130)
+test_channel_scattering_angles = scattering_angle(test_channel_radius)
+
+
+def superguass(x, c, w, n=4):
+    z = (x - c) / w
+    return exp(-0.5 * z**n)
+
+
+def logistic(x):
+    return 1 / (1 + exp(-x))
+
+
+def logistic_product(x, c, w, sigma):
+    z1 = (x - (c - w)) / sigma
+    z2 = (x - (c + w)) / sigma
+    return logistic(z1) * (1 - logistic(z2))
+
+
+def build_testing_instrument(n_points: int = 20, spatial_channels=None):
+    R0 = test_channel_radius if spatial_channels is None else test_channel_radius[spatial_channels]
+    dR = linspace(-0.0075, 0.0075, n_points)
+    R = R0[:, None] + dR[None, :]
+    angles = scattering_angle(R)
+
+    y = logistic_product(dR, c=0.0, w=0.005, sigma=4e-4)
+    weights = tile(y, (R0.size, 1))
+
+    return InstrumentFunction(
+        radius=R,
+        scattering_angle=angles,
+        weights=weights
+    )
+
+
+def build_testing_filters():
+    # parameters for a set of testing polychromator filters
+    # generated using super-gaussians
+    wavelength_starts = [1.053e-06, 1.035e-06, 9.8e-07, 8.1e-07]
+    wavelength_ends = [1.064e-06, 1.06e-06, 1.0462e-06, 1.0075e-06]
+    amplitudes = [1.0, 1.14, 1.43, 1.6]
+    widths = [2.55e-9, 7e-9, 2.1e-8, 7.1e-8]
+    centres = [1.058e-6, 1.0477e-6, 1.018e-6, 9.19e-7]
+    exponents = [4, 8, 10, 12]
+
+    # build the transmission data
+    wavelengths = zeros([130, 4, 128])
+    transmissions = zeros([130, 4, 128])
+    for i in range(4):
+        wavelengths[:, i, :] = linspace(wavelength_starts[i], wavelength_ends[i], 128)[None, :]
+        transmissions[:, i, :] = amplitudes[i] * superguass(
+            wavelengths[:, i, :], c=centres[i], w=widths[i], n=exponents[i]
+        )[None, :]
+
+    return wavelengths, transmissions

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -1,6 +1,6 @@
 from numpy import exp, linspace, zeros, ndarray, meshgrid, array
 from pedinf.spectrum import SpectralResponse, calculate_filter_response
-from tests.data import build_testing_filters, test_channel_scattering_angles
+from data import build_testing_filters, test_channel_scattering_angles
 
 
 def generate_test_response_data(

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -1,5 +1,6 @@
-from numpy import exp, linspace, zeros, arange, ndarray, meshgrid, array
+from numpy import exp, linspace, zeros, ndarray, meshgrid, array
 from pedinf.spectrum import SpectralResponse, calculate_filter_response
+from tests.data import build_testing_filters, test_channel_scattering_angles
 
 
 def generate_test_response_data(
@@ -52,41 +53,9 @@ def generate_test_response_data(
     return ln_te_axes, scattering_angle_axes, response, gradient
 
 
-def superguass(x, c, w, n=4):
-    z = (x - c) / w
-    return exp(-0.5 * z**n)
-
-
-def generate_testing_filters():
-    # parameters for a set of testing polychromator filters
-    # generated using super-gaussians
-    wavelength_starts = [1.053e-06, 1.035e-06, 9.8e-07, 8.1e-07]
-    wavelength_ends = [1.064e-06, 1.06e-06, 1.0462e-06, 1.0075e-06]
-    amplitudes = [1.0, 1.14, 1.43, 1.6]
-    widths = [2.55e-9, 7e-9, 2.1e-8, 7.1e-8]
-    centres = [1.058e-6, 1.0477e-6, 1.018e-6, 9.19e-7]
-    exponents = [4, 8, 10, 12]
-
-    # build the transmission data
-    wavelengths = zeros([130, 4, 128])
-    transmissions = zeros([130, 4, 128])
-    for i in range(4):
-        wavelengths[:, i, :] = linspace(wavelength_starts[i], wavelength_ends[i], 128)[None, :]
-        transmissions[:, i, :] = amplitudes[i] * superguass(
-            wavelengths[:, i, :], c=centres[i], w=widths[i], n=exponents[i]
-        )[None, :]
-
-    # pick a few channels which cover the full range of scattering angles
-    spatial_channels = array([0, 33, 66, 99, 129])
-    # generate testing scattering angles from a quadratric
-    coeffs = [7.85941e-07, -6.43046e-03, 2.1297]
-    full_chans = arange(0, 130)
-    scattering_angles = coeffs[2] + full_chans * coeffs[1] + full_chans ** 2 * coeffs[0]
-    return wavelengths, transmissions, scattering_angles, spatial_channels
-
-
 def test_spectrum_model():
-    wavelengths, transmissions, scattering_angles, spatial_channels = generate_testing_filters()
+    wavelengths, transmissions = build_testing_filters()
+    spatial_channels = array([0, 33, 66, 99, 129])
     n_chans = spatial_channels.size
     # specify knots settings, and also test-points inbetween the knots
     knot_range = (-3., 10.)
@@ -100,7 +69,7 @@ def test_spectrum_model():
         wavelengths=wavelengths,
         transmissions=transmissions,
         spatial_channels=spatial_channels,
-        scattering_angles=scattering_angles,
+        scattering_angles=test_channel_scattering_angles,
         ln_te_range=knot_range,
         n_temps=n_knots,
         jit_compile=False
@@ -111,7 +80,7 @@ def test_spectrum_model():
         wavelengths=wavelengths,
         transmissions=transmissions,
         spatial_channels=spatial_channels,
-        scattering_angles=scattering_angles,
+        scattering_angles=test_channel_scattering_angles,
         ln_te_range=test_range,
         n_temps=n_test_temps,
     )

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -72,7 +72,7 @@ def test_spectrum_model():
         scattering_angles=test_channel_scattering_angles,
         ln_te_range=knot_range,
         n_temps=n_knots,
-        jit_compile=False
+        jit_compile=None
     )
 
     # generate the target values for spectral response and its gradient


### PR DESCRIPTION
 - Added `numba` as an additional option for JIT compilation. Previously the `jit_compile` keyword argument expected a `bool`, but now accepts either `"jax"`, `"numba"` or `None` to select what jit-compilation is used.
 - Added tools to support easier performance benchmarking.